### PR TITLE
Add Customer.io v2 track resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,28 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ### Client
 
-Customer.io API client is initialized with an API key which is used for bearer token authentication.
+#### V1Client
+
+V1Client is used to retreive data for the following resources:
+
+- Customer
+- CustomerioObject
+- ObjectRelationship
+
+V1Client is initialized with an API key which is used for bearer token authentication.
 
 ```ruby
-client = CustomerioAPI::Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
+v1_client = CustomerioAPI::V1Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
+```
+
+#### V2Client
+
+V2Client is used to perform various operations based on the type (person, object or delivery) and action (identify, add_relationships, delete, etc) that you set in the request.
+
+V2Client is initialized with a site_id and track_api_key which is used for basic authentication.
+
+```ruby
+v2_client = CustomerioAPI::V2Client.new(site_id: ENV['SITE_ID'], track_api_key: ENV['TRACK_API_KEY'])
 ```
 
 ### Customer
@@ -27,9 +45,9 @@ client = CustomerioAPI::Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
 #### 1. Get a list of customers by email
 
 ```ruby
-customers = client.customer.where(email: 'test@example.com')
+customers = v1_client.customer.where(email: 'test@example.com')
 
-# => returns a list of Customerio::Customer
+# => returns a list of CustomerioAPI::Customer
 ```
 
 ### CustomerioObject
@@ -59,9 +77,9 @@ attributes =
 start = "0"
 limit = 10
 
-client.object.where(attributes: attributes, start: start, limit: limit)
+v1_client.object.where(attributes: attributes, start: start, limit: limit)
 
-# => returns a Customerio::CustomerioObject
+# => returns a CustomerioAPI::CustomerioObject
 ```
 
 ### ObjectRelationship
@@ -71,9 +89,38 @@ client.object.where(attributes: attributes, start: start, limit: limit)
 ```ruby
 # query_params is optional
 query_params = {start: string, limit: integer, id_type: "object_id" | "cio_object_id"}
-client.object_relationship.where(object_type_id: 1, object_id: 'PostCo', query_params: query_params)
+v1_client.object_relationship.where(object_type_id: 1, object_id: 'PostCo', query_params: query_params)
 
-# => returns a Customerio::ObjectRelationship
+# => returns a CustomerioAPI::ObjectRelationship
+```
+
+### Track
+
+#### 1. Single request
+
+This endpoint lets create, update, or delete a single person or object—including managing relationships between objects and people.
+
+```ruby
+# Create a person
+attributes = { type: 'object', action: 'identify', identifiers: { object_type_id: '1', object_id: 'test'}, attributes: {name: "test"} }
+v2_client.track.entity(attributes)
+
+# => returns {}
+```
+
+#### 2. Multiple request
+
+This endpoint lets you batch requests for different people and objects in a single request.
+
+```ruby
+# Update multiple objects
+attributes = [
+    { type: 'object', action: 'identify', identifiers: { object_type_id: '1', object_id: 'shop-1' }, attributes: { name: 'Shop 1 updated' } },
+    { type: 'object', action: 'identify', identifiers: { object_type_id: '1', object_id: 'shop-2' }, attributes: { name: 'Shop 2 updated' } }
+    ]
+v2_client.track.batch(attributes)
+
+# => returns {}
 ```
 
 ## Development

--- a/bin/console
+++ b/bin/console
@@ -8,7 +8,8 @@ require 'customerio_api'
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-@client = CustomerioAPI::Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
+@v1_client = CustomerioAPI::V1Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
+@v2_client = CustomerioAPI::V2Client.new(site_id: ENV['SITE_ID'], track_api_key: ENV['TRACK_API_KEY'])
 
 # (If you use this, don't forget to add pry to your Gemfile!)
 require 'pry'
@@ -16,4 +17,3 @@ Pry.start
 
 # require 'irb'
 # IRB.start(__FILE__)
-

--- a/lib/customerio_api/resources/track_resource.rb
+++ b/lib/customerio_api/resources/track_resource.rb
@@ -1,0 +1,26 @@
+module CustomerioAPI
+  class TrackResource < Resource
+    # Example: Create/Update a Shop object
+    # attributes = { type: 'object', action: 'identify', identifiers: { object_type_id: '2', object_id: 'linh-us'}, attributes: {name: "linh-us"} }
+    # v2_client.track.entity(attributes)
+    # Response: {}
+
+    def entity(attributes)
+      post_request('entity', body: attributes).body
+    end
+
+    # Example: Create/Update multiple objects
+    # attributes: an array of people or objects
+    # attributes = [
+    #   { type: 'object', action: 'identify', identifiers: { object_type_id: '1', object_id: 'linh-us' }, attributes: { name: 'linh-us' } },
+    #   { type: 'object', action: 'identify', identifiers: { object_type_id: '1', object_id: 'PostCo' }, attributes: { name: 'PostCo' } }
+    #   ]
+
+    # v2_client.track.batch(attributes)
+    # Response: {}
+
+    def batch(attributes)
+      post_request('batch', body: { batch: attributes }).body
+    end
+  end
+end

--- a/lib/customerio_api/v1_client.rb
+++ b/lib/customerio_api/v1_client.rb
@@ -3,7 +3,7 @@
 require 'faraday'
 
 module CustomerioAPI
-  class Client
+  class V1Client
     BASE_URL = 'https://api.customer.io/v1/'
     attr_reader :api_key, :adapter
 

--- a/lib/customerio_api/v2_client.rb
+++ b/lib/customerio_api/v2_client.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'faraday'
+
+module CustomerioAPI
+  class V2Client
+    BASE_URL = 'https://track.customer.io/api/v2/'
+    attr_reader :site_id, :track_api_key, :adapter
+
+    def initialize(site_id:, track_api_key:, adapter: Faraday.default_adapter)
+      @track_api_key = track_api_key
+      @site_id = site_id
+      @adapter = adapter
+    end
+
+    def track
+      TrackResource.new(self)
+    end
+
+    def connection
+      @connection ||= Faraday.new do |conn|
+        conn.url_prefix = BASE_URL
+        conn.request :json
+        conn.response :json, content_type: 'application/json'
+        conn.adapter adapter
+        conn.request :authorization, :basic, site_id, track_api_key
+      end
+    end
+  end
+end

--- a/spec/customerio_api/resources/customer_resource_spec.rb
+++ b/spec/customerio_api/resources/customer_resource_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CustomerioAPI::CustomerResource do
   subject { described_class.new(client) }
 
   let!(:client) do
-    CustomerioAPI::Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
+    CustomerioAPI::V1Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
   end
 
   describe '#where(email:)' do

--- a/spec/customerio_api/resources/customerio_object_resource_spec.rb
+++ b/spec/customerio_api/resources/customerio_object_resource_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CustomerioAPI::CustomerioObjectResource do
   subject { described_class.new(client) }
 
   let!(:client) do
-    CustomerioAPI::Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
+    CustomerioAPI::V1Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
   end
 
   describe '#where(attributes:)' do

--- a/spec/customerio_api/resources/object_relationship_resource_spec.rb
+++ b/spec/customerio_api/resources/object_relationship_resource_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CustomerioAPI::ObjectRelationshipResource do
   subject { described_class.new(client) }
 
   let!(:client) do
-    CustomerioAPI::Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
+    CustomerioAPI::V1Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
   end
 
   describe '#where(object_type_id:, object_id:, query_params: {})' do

--- a/spec/customerio_api/resources/track_resource_spec.rb
+++ b/spec/customerio_api/resources/track_resource_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe CustomerioAPI::TrackResource do
+  subject { described_class.new(client) }
+
+  let!(:client) do
+    CustomerioAPI::V2Client.new(site_id: ENV['SITE_ID'], track_api_key: ENV['TRACK_API_KEY'])
+  end
+
+  describe 'entity(attributes)' do
+    before do
+      stub_request(:post, 'https://track.customer.io/api/v2/entity')
+        .with(body: attributes, basic_auth: [ENV['SITE_ID'], ENV['TRACK_API_KEY']])
+        .to_return_json(status: status_code, body: response_body)
+    end
+
+    context 'when sucessfully create a person' do
+      let(:attributes) do
+        { type: 'object', action: 'identify', identifiers: { object_type_id: '1', object_id: 'linh-us' },
+          attributes: { name: 'linh-us' } }
+      end
+      let(:response_body) { {} }
+      let(:status_code) { 200 }
+
+      it do
+        result = subject.entity(attributes)
+        expect(result).to eq({})
+      end
+    end
+
+    context 'when failed to create a person' do
+      let(:attributes) do
+        { type: 'object', identifiers: { object_type_id: '1', object_id: 'linh-us' }, attributes: { name: 'linh-us' } }
+      end
+      let(:response_body) do
+        { 'errors': [{ 'reason': 'required', 'field': 'action',
+                       'message': 'must be one of add_relationships, delete, delete_relationships, identify or identify_anonymous' }] }
+      end
+      let(:status_code) { 400 }
+
+      it do
+        expect { subject.entity(attributes) }.to raise_error(CustomerioAPI::Error)
+      end
+    end
+  end
+
+  describe 'batch(attributes)' do
+    before do
+      stub_request(:post, 'https://track.customer.io/api/v2/batch')
+        .with(body: { batch: attributes }, basic_auth: [ENV['SITE_ID'], ENV['TRACK_API_KEY']])
+        .to_return_json(status: status_code, body: response_body)
+    end
+
+    context 'when sucessfully batch update' do
+      let(:attributes) do
+        [
+          { type: 'object', action: 'identify', identifiers: { object_type_id: '1', object_id: 'linh-us' },
+            attributes: { name: 'linh-us' } },
+          { type: 'object', action: 'identify', identifiers: { object_type_id: '1', object_id: 'PostCo' },
+            attributes: { name: 'PostCo' } }
+        ]
+      end
+      let(:response_body) { {} }
+      let(:status_code) { 200 }
+
+      it do
+        result = subject.batch(attributes)
+        expect(result).to eq({})
+      end
+    end
+
+    context 'when failed to batch update' do
+      let(:attributes) do
+        { type: 'object', action: 'identify', identifiers: { object_type_id: '1', object_id: 'PostCo' },
+          attributes: { name: 'PostCo' } }
+      end
+      let(:response_body) do
+        { 'errors': [{ "reason": 'invalid', "field": 'body', "message": 'must be valid JSON' }] }
+      end
+      let(:status_code) { 400 }
+
+      it do
+        expect { subject.batch(attributes) }.to raise_error(CustomerioAPI::Error)
+      end
+    end
+  end
+end

--- a/spec/customerio_api/v1_client_spec.rb
+++ b/spec/customerio_api/v1_client_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe CustomerioAPI::Client do
+RSpec.describe CustomerioAPI::V1Client do
   subject do
-    CustomerioAPI::Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
+    CustomerioAPI::V1Client.new(api_key: ENV['CUSTOMERIO_API_KEY'])
   end
 
   it 'uses correct base url' do
-    expect(CustomerioAPI::Client::BASE_URL).to eq('https://api.customer.io/v1/')
+    expect(CustomerioAPI::V1Client::BASE_URL).to eq('https://api.customer.io/v1/')
   end
 
   context '#customer' do

--- a/spec/customerio_api/v2_client_spec.rb
+++ b/spec/customerio_api/v2_client_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe CustomerioAPI::V2Client do
+  subject do
+    CustomerioAPI::V2Client.new(site_id: ENV['SITE_ID'], track_api_key: ENV['TRACK_API_KEY'])
+  end
+
+  it 'uses correct base url' do
+    expect(CustomerioAPI::V2Client::BASE_URL).to eq('https://track.customer.io/api/v2/')
+  end
+
+  context '#track' do
+    it { expect(subject.track).to be_a(CustomerioAPI::TrackResource) }
+  end
+
+  context '#connection' do
+    it do
+      connection = subject.connection
+      expect(connection.builder.adapter).to eq(Faraday::Adapter::NetHttp)
+      expect(connection.builder.handlers).to include(
+        Faraday::Request::Json,
+        Faraday::Response::Json,
+        Faraday::Request::Authorization
+      )
+    end
+  end
+end


### PR DESCRIPTION
 I think it's better to separate the client into 2 different classes, `ClientV1` and `ClientV2`. Because they have 2 different endpoint URLs and authoriztion method which requires different params to initialize. With that we can just simply initialize the client that we need.

What do you think?